### PR TITLE
Inject inline styles dynamically for JTL compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,14 @@
     </div>
   </div>
   
-  <style>
+  <script>
+  (function injectBrandStyles() {
+    const STYLE_ID = 'brand-list-styles';
+    if (document.getElementById(STYLE_ID)) return;
+
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
     :root {
       --primary: #197149;
       --primary-hover: #0b3e27;
@@ -364,9 +371,11 @@
         padding: 14px 16px;
       }
     }
-  </style>
-  
-  <script>
+    `;
+
+    (document.head || document.body || document.documentElement).appendChild(style);
+  })();
+
   document.addEventListener('DOMContentLoaded', () => {
     /* === 1) Link veri setleri === */
     // PKW (binek)
@@ -585,7 +594,7 @@
   
     /* === 5) Event bağlama === */
     loadMoreBtn.addEventListener('click', toggleLoadMore);
-    tabPKW.addEventListener('click', () => switchTab('PKW'));    git push -u origin master
+    tabPKW.addEventListener('click', () => switchTab('PKW'));
     tabWohn.addEventListener('click', () => switchTab('Wohnmobil'));
   
     /* === 6) Başlat === */


### PR DESCRIPTION
## Summary
- inject the component's CSS from JavaScript so it still loads when the CMS strips `<style>` blocks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62fd145e88320a6941ff996489fa2